### PR TITLE
Fix two flaky tests in DisabledSchemaValidationTest and RetryInterceptorTest

### DIFF
--- a/activiti-core/activiti-engine/src/test/java/org/activiti/engine/test/cfg/RetryInterceptorTest.java
+++ b/activiti-core/activiti-engine/src/test/java/org/activiti/engine/test/cfg/RetryInterceptorTest.java
@@ -58,6 +58,7 @@ public class RetryInterceptorTest {
   @After
   public void shutdownProcessEngine() {
     processEngine.close();
+    counter.set(0);
   }
 
   @Test

--- a/activiti-core/activiti-engine/src/test/java/org/activiti/standalone/validation/DisabledSchemaValidationTest.java
+++ b/activiti-core/activiti-engine/src/test/java/org/activiti/standalone/validation/DisabledSchemaValidationTest.java
@@ -52,7 +52,7 @@ public class DisabledSchemaValidationTest {
     for (Deployment deployment : repositoryService.createDeploymentQuery().list()) {
       repositoryService.deleteDeployment(deployment.getId());
     }
-
+    processEngine.close();
     ProcessEngines.unregister(processEngine);
     processEngine = null;
     repositoryService = null;


### PR DESCRIPTION
It is observed that the following two tests are not idempotent and would fail when run twice in the same test run:
- org.activiti.standalone.validation.DisabledSchemaValidationTest.testDisableValidation
- org.activiti.engine.test.cfg.RetryInterceptorTest.testRetryInterceptor

This PR proposes fixes to these two tests so that they become idempotent.

Details for DisabledSchemaValidationTest.testDisableValidation
---
When running DisabledSchemaValidationTest.testDisableValidation twice, the second run would fail with the following stack trace:
```
org.h2.jdbc.JdbcSQLException: Table "ACT_HI_PROCINST" already exists; SQL statement:
create table ACT_HI_PROCINST ()
at org.h2.message.DbException.getJdbcSQLException(DbException.java:357)
at org.h2.message.DbException.get(DbException.java:179)
at org.h2.message.DbException.get(DbException.java:155)
at org.h2.command.ddl.CreateTable.update(CreateTable.java:86)
at org.h2.command.CommandContainer.update(CommandContainer.java:102)
at org.h2.command.Command.executeUpdate(Command.java:261)
at org.h2.jdbc.JdbcStatement.executeInternal(JdbcStatement.java:233)
at org.h2.jdbc.JdbcStatement.execute(JdbcStatement.java:205)
at org.activiti.engine.impl.db.DbSqlSession.executeSchemaResource(DbSqlSession.java:1390)
at org.activiti.engine.impl.db.DbSqlSession.executeSchemaResource(DbSqlSession.java:1299)
at org.activiti.engine.impl.db.DbSqlSession.executeMandatorySchemaResource(DbSqlSession.java:1034)
at org.activiti.engine.impl.db.DbSqlSession.dbSchemaCreateHistory(DbSqlSession.java:1007)
at org.activiti.engine.impl.db.DbSqlSession.dbSchemaCreate(DbSqlSession.java:1002)
at org.activiti.engine.impl.db.DbSqlSession.performSchemaOperationsProcessEngineBuild(DbSqlSession.java:1497)
at org.activiti.engine.impl.SchemaOperationsProcessEngineBuild.execute(SchemaOperationsProcessEngineBuild.java:28)
at org.activiti.engine.impl.interceptor.CommandInvoker$1.run(CommandInvoker.java:37)
at org.activiti.engine.impl.interceptor.CommandInvoker.executeOperation(CommandInvoker.java:78)
at org.activiti.engine.impl.interceptor.CommandInvoker.executeOperations(CommandInvoker.java:57)
at org.activiti.engine.impl.interceptor.CommandInvoker.execute(CommandInvoker.java:42)
at org.activiti.engine.impl.interceptor.TransactionContextInterceptor.execute(TransactionContextInterceptor.java:48)
at org.activiti.engine.impl.interceptor.CommandContextInterceptor.execute(CommandContextInterceptor.java:63)
at org.activiti.engine.impl.interceptor.LogInterceptor.execute(LogInterceptor.java:29)
at org.activiti.engine.impl.cfg.CommandExecutorImpl.execute(CommandExecutorImpl.java:44)
at org.activiti.engine.impl.ProcessEngineImpl.<init>(ProcessEngineImpl.java:68)
at org.activiti.engine.impl.cfg.ProcessEngineConfigurationImpl.buildProcessEngine(ProcessEngineConfigurationImpl.java:858)
at org.activiti.standalone.validation.DisabledSchemaValidationTest.setup(DisabledSchemaValidationTest.java:41)
```
The reason for this is that the same DbSqlSession is shared between two test runs, and db table "ACT_HI_PROCINST" is already created in the first test run. The fix is to close the process engine in the teardown() function to ensure DbSqlSession is cleaned up after each run.

Details for RetryInterceptorTest.testRetryInterceptor
-------------------------
When running RetryInterceptorTest.testRetryInterceptor twice, the second run would fail with the following assertion error:
```
java.lang.AssertionError: Expected :4. Actual   :8 (RetryInterceptorTest:80 expected:<[4]> but was:<[8]>)
```
The root cause is that the assertion is made to a static counter, which is incremented by each of the two test runs. The fix for this is to reset the static counter to 0 in shutdownProcessEngine().

With the proposed fixes, each test pass when running twice.